### PR TITLE
variable explorer updates

### DIFF
--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -20,13 +20,10 @@ def inbound_comm(comm, open_msg):
         # TODO: pydantic discriminators for message types->handlers
         if data.get("msg") == "get_kernel_variables":
             variables = get_kernel_variables()
-            msg = CommMessage(body=variables)
-            comm.send(
-                {
-                    "body": msg.dict(),
-                    "source": "sidecar_comms",
-                    "handler": "get_kernel_variables",
-                }
+            msg = CommMessage(
+                body=variables,
+                handler="get_kernel_variables",
             )
+            comm.send(msg.dict())
 
     comm.send({"status": "connected", "source": "inbound_comm"})

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -5,6 +5,7 @@ Comm target registration and message handling for inbound messages.
 
 
 from sidecar_comms.handlers.main import get_kernel_variables
+from sidecar_comms.models import CommMessage
 
 
 def inbound_comm(comm, open_msg):
@@ -18,7 +19,14 @@ def inbound_comm(comm, open_msg):
 
         # TODO: pydantic discriminators for message types->handlers
         if data.get("msg") == "get_kernel_variables":
-            msg = get_kernel_variables()
-            comm.send({"data": msg})
+            variables = get_kernel_variables()
+            msg = CommMessage(body=variables)
+            comm.send(
+                {
+                    "body": msg.dict(),
+                    "source": "sidecar_comms",
+                    "handler": "get_kernel_variables",
+                }
+            )
 
     comm.send({"status": "connected", "source": "inbound_comm"})

--- a/src/sidecar_comms/models.py
+++ b/src/sidecar_comms/models.py
@@ -15,3 +15,4 @@ class CommMessage(BaseModel):
     body: dict = Field(default_factory=dict)
     comm_id: Optional[str] = None
     target_name: Optional[str] = None
+    handler: Optional[str] = None

--- a/src/sidecar_comms/models.py
+++ b/src/sidecar_comms/models.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Any, Dict, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -10,16 +10,8 @@ class SidecarRequestType(enum.Enum):
     kernel_state = "kernel_state"
 
 
-class CommMessageBody(BaseModel):
-    request: Optional[SidecarRequestType]
-    data: Optional[Dict[str, Any]]
-
-    class Config:
-        use_enum_values = True
-
-
 class CommMessage(BaseModel):
     source: Literal["sidecar_comms"] = "sidecar_comms"
-    body: CommMessageBody = Field(default_factory=CommMessageBody)
+    body: dict = Field(default_factory=dict)
     comm_id: Optional[str] = None
     target_name: Optional[str] = None


### PR DESCRIPTION
- replaces `CommMessage` body with `dict` and removes `CommMessageBody`
- `get_kernel_variables` handler sends message back using `CommMessage` model