### PR TITLE
hotfix for `register_comm_target`

### DIFF
--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -102,9 +102,6 @@ class SliderSettings(ObservableModel):
     max: Union[int, float] = 10
     step: Union[int, float] = Field(default=1, gt=0)
 
-    class Config:
-        validate_assignment = True
-
 
 class Slider(FormCellBase):
     input_type: Literal["slider"] = "slider"

--- a/src/sidecar_comms/outbound.py
+++ b/src/sidecar_comms/outbound.py
@@ -57,7 +57,7 @@ class CommManager:
             body={"target": target_name},
             handler="register_comm_target",
         )
-        comm.send(msg.dict())
+        comm.send(**msg.dict())
 
         # if a message with {"value": X} is sent to this comm,
         # update the comm's value attribute


### PR DESCRIPTION
- unpack `msg` on `register_comm_target()` to avoid validation errors on `comm_id`
- clarify msg variable names on echo/error