### PR TITLE
general maintenance

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -360,18 +360,6 @@ files = [
 ]
 
 [[package]]
-name = "deepmerge"
-version = "1.1.0"
-description = "a toolset to deeply merge python dictionaries."
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "deepmerge-1.1.0-py3-none-any.whl", hash = "sha256:59e6ef80b77dc52af3882a1ea78da22bcfc91ae9cdabc0c80729049fe295ff8b"},
-    {file = "deepmerge-1.1.0.tar.gz", hash = "sha256:4c27a0db5de285e1a7ceac7dbc1531deaa556b627dea4900c8244581ecdfea2d"},
-]
-
-[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -1374,4 +1362,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0a898cc5f1603bac4b1242b5ba88fc247216737ca164de1843b77d57687da152"
+content-hash = "12ca154f5594993286e5b12e80dac3c508fe5ecfab9c58daab0ade1b800b69f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/noteable-io/sidecar_comms"
 python = "^3.8"
 ipykernel = "^6.20.2"
 pydantic = "^1.10.2"
-deepmerge = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.12.0"

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -120,6 +120,19 @@ class FormCellBase(ObservableModel):
         self._comm.send(handler="display_form_cell", body=self.dict())
         print(self.__repr__())
 
+    def update(self, data: dict) -> None:
+        """Set attributes on a form cell from a dict of values.
+
+        NOTE: for any deep merging beyond or deeper than `settings`, we will
+        need to revisit/rethink this. For now, we only get top-level changes
+        and `settings` changes that are one level deep."""
+        for name, value in data.items():
+            if name == "settings":
+                for setting_name, setting_value in value.items():
+                    setattr(self.settings, setting_name, setting_value)
+                continue
+        setattr(self, name, value)
+
 
 # --- Specific models ---
 class Datetime(FormCellBase):
@@ -221,18 +234,3 @@ def parse_as_form_cell(data: dict) -> FormCell:
     if data["input_type"] not in valid_model_input_types:
         data["input_type"] = "custom"
     return parse_obj_as(FormCell, data)
-
-
-def update_form_cell(form_cell: FormCell, data: dict):
-    """Set attributes on a form cell from a dict of values.
-
-    NOTE: for any deep merging beyond or deeper than `settings`, we will
-    need to revisit/rethink this. For now, we only get top-level changes
-    and `settings` changes that are one level deep."""
-    for name, value in data.items():
-        if name == "settings":
-            for setting_name, setting_value in value.items():
-                setattr(form_cell.settings, setting_name, setting_value)
-            continue
-        setattr(form_cell, name, value)
-    return form_cell

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -225,7 +225,6 @@ model_union = Union[
 FormCell = Annotated[model_union, Field(discriminator="input_type")]
 # we don't have any other way to check whether an `input_type` value is valid
 valid_model_input_types = [m.__fields__["input_type"].default for m in model_union.__args__]
-default_model_callbacks = ["_sync_sidecar", "_on_value_update"]
 
 
 def parse_as_form_cell(data: dict) -> FormCell:

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -37,7 +37,7 @@ from pydantic.utils import deep_update
 from typing_extensions import Annotated
 
 from sidecar_comms.form_cells.observable import Change, ObservableModel
-from sidecar_comms.handlers.main import set_kernel_variable
+from sidecar_comms.handlers.variable_explorer import set_kernel_variable
 from sidecar_comms.outbound import SidecarComm, comm_manager
 
 FORM_CELL_CACHE: Dict[str, "FormCellBase"] = {}

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -62,7 +62,6 @@ class FormCellBase(ObservableModel):
     """
 
     _comm: SidecarComm = PrivateAttr()
-    _ipy: Optional[InteractiveShell] = PrivateAttr()
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     label: str = ""
     model_variable_name: str = ""
@@ -73,6 +72,9 @@ class FormCellBase(ObservableModel):
     execution_trigger_behavior: ExecutionTriggerBehavior = (
         ExecutionTriggerBehavior.change_variable_only
     )
+
+    # only used for tests
+    _ipy: Optional[InteractiveShell] = PrivateAttr()
 
     def __init__(self, ipython_shell: Optional[InteractiveShell] = None, **data):
         super().__init__(**data)

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -163,14 +163,14 @@ class OptionsSettings(ObservableModel):
 class Dropdown(FormCellBase):
     input_type: Literal["dropdown"] = "dropdown"
     value: str = ""
-    variable_type: Union[str, dict]
+    variable_type: Union[str, dict] = ""
     settings: OptionsSettings = Field(default_factory=OptionsSettings)
 
 
 class Checkboxes(FormCellBase):
     input_type: Literal["checkboxes"] = "checkboxes"
     value: List[str] = Field(default_factory=list)
-    variable_type: Union[str, dict]
+    variable_type: Union[str, dict] = ""
     settings: OptionsSettings = Field(default_factory=OptionsSettings)
 
 

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -105,6 +105,9 @@ class FormCellBase(ObservableModel):
         self._comm.send(handler="update_form_cell", body=self.dict())
 
     def _on_value_update(self, change: Change) -> None:
+        """Update the kernel variable when the .value changes
+        based on the associated .value_variable_name.
+        """
         set_kernel_variable(
             self.value_variable_name,
             change.new,

--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -131,7 +131,7 @@ class FormCellBase(ObservableModel):
                 for setting_name, setting_value in value.items():
                     setattr(self.settings, setting_name, setting_value)
                 continue
-        setattr(self, name, value)
+            setattr(self, name, value)
 
 
 # --- Specific models ---

--- a/src/sidecar_comms/handlers/main.py
+++ b/src/sidecar_comms/handlers/main.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
@@ -23,6 +23,20 @@ def rename_kernel_variable(
         if new_name:
             ipython.user_ns[new_name] = ipython.user_ns[old_name]
         del ipython.user_ns[old_name]
+        return "success"
+    except Exception as e:
+        return str(e)
+
+
+def set_kernel_variable(
+    name: str,
+    value: Any,
+    ipython_shell: Optional[InteractiveShell] = None,
+) -> str:
+    """Sets a variable in the kernel."""
+    ipython = ipython_shell or get_ipython()
+    try:
+        ipython.user_ns[name] = value
         return "success"
     except Exception as e:
         return str(e)

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -1,14 +1,47 @@
+import sys
 from typing import Any, Optional
 
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
 
 
-def get_kernel_variables():
+def short_value(value: Any) -> str:
+    """Returns a short representation of a value."""
+    if isinstance(value, list):
+        return value[:5]
+    if isinstance(value, dict):
+        return value.keys()
+    if sys.getsizeof(value) > 1000:
+        return f"{value!r}"[:100] + "..."
+    return value
+
+
+def get_kernel_variables(
+    skip_prefixes: list = None, ipython_shell: Optional[InteractiveShell] = None
+):
     """Returns a list of variables in the kernel."""
-    ipython = get_ipython()
+    ipython = ipython_shell or get_ipython()
     variables = dict(ipython.user_ns)
-    variable_types = {name: str(type(value)) for name, value in variables.items()}
+
+    skip_prefixes = skip_prefixes or [
+        "_",
+        "In",
+        "Out",
+        "get_ipython",
+        "exit",
+        "quit",
+        "open",
+    ]
+    variable_types = {}
+    for name, value in variables.items():
+        if name.startswith(tuple(skip_prefixes)):
+            continue
+        variable_types[name] = {
+            "name": name,
+            "type": type(value).__name__,
+            "size": len(value) if hasattr(value, "__len__") else 1,
+            "value": short_value(value),
+        }
     return variable_types
 
 

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -5,10 +5,10 @@ Comm target registration and message handling for inbound messages.
 import traceback
 from typing import Optional
 
-from deepmerge import always_merger
 from ipykernel.comm import Comm
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
+from pydantic.utils import deep_update
 
 from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell
 from sidecar_comms.handlers.main import get_kernel_variables, rename_kernel_variable
@@ -75,7 +75,7 @@ def handle_msg(
         form_cell_id = data.pop("form_cell_id")
         form_cell = FORM_CELL_CACHE[form_cell_id]
         # deep merge the original form cell with the update data
-        update_data = always_merger.merge(form_cell.dict(), data)
+        update_data = deep_update(form_cell.dict(), data)
         # convert back to one of our FormCell types
         updated_form_cell = parse_as_form_cell(update_data)
         # TODO: migrate the observers from previous form cell to new one

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -11,7 +11,11 @@ from IPython.core.interactiveshell import InteractiveShell
 from pydantic.utils import deep_update
 
 from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell
-from sidecar_comms.handlers.main import get_kernel_variables, rename_kernel_variable
+from sidecar_comms.handlers.main import (
+    get_kernel_variables,
+    rename_kernel_variable,
+    set_kernel_variable,
+)
 from sidecar_comms.models import CommMessage
 
 
@@ -108,5 +112,4 @@ def handle_msg(
     if inbound_msg == "assign_value_variable":
         form_cell_id = data["form_cell_id"]
         form_cell = FORM_CELL_CACHE[form_cell_id]
-        value_variable_name = data["value_variable_name"]
-        form_cell._update_value_variable(value_variable_name)
+        set_kernel_variable(data["value_variable_name"], form_cell.value)

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -9,7 +9,7 @@ from ipykernel.comm import Comm
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
 
-from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell, update_form_cell
+from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell
 from sidecar_comms.handlers.variable_explorer import (
     get_kernel_variables,
     rename_kernel_variable,

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -77,15 +77,12 @@ def handle_msg(
     if inbound_msg == "update_form_cell":
         form_cell_id = data.pop("form_cell_id")
         form_cell = FORM_CELL_CACHE[form_cell_id]
-        updated_form_cell = update_form_cell(form_cell, data)
+        form_cell.update(data)
         msg = CommMessage(
-            body=updated_form_cell.dict(),
+            body=form_cell.dict(),
             handler="update_form_cell",
         )
         comm.send(msg.dict())
-
-        FORM_CELL_CACHE[form_cell_id] = updated_form_cell
-        get_ipython().user_ns[data["model_variable_name"]] = updated_form_cell
 
     if inbound_msg == "create_form_cell":
         # form cell object created from the frontend

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -10,7 +10,7 @@ from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
 
 from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell, update_form_cell
-from sidecar_comms.handlers.main import (
+from sidecar_comms.handlers.variable_explorer import (
     get_kernel_variables,
     rename_kernel_variable,
     set_kernel_variable,

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -8,9 +8,8 @@ from typing import Optional
 from ipykernel.comm import Comm
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
-from pydantic.utils import deep_update
 
-from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell
+from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell, update_form_cell
 from sidecar_comms.handlers.main import (
     get_kernel_variables,
     rename_kernel_variable,
@@ -78,13 +77,7 @@ def handle_msg(
     if inbound_msg == "update_form_cell":
         form_cell_id = data.pop("form_cell_id")
         form_cell = FORM_CELL_CACHE[form_cell_id]
-        # deep merge the original form cell with the update data
-        update_data = deep_update(form_cell.dict(), data)
-        # convert back to one of our FormCell types
-        updated_form_cell = parse_as_form_cell(update_data)
-        # TODO: migrate the observers from previous form cell to new one
-        # updated_form_cell._observers = form_cell._observers
-        # send a comm back to the sidecar to update form cell tracking
+        updated_form_cell = update_form_cell(form_cell, data)
         msg = CommMessage(
             body=updated_form_cell.dict(),
             handler="update_form_cell",

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -21,6 +21,7 @@ class TestParseFormCell:
             "settings": {
                 "options": ["test"],
             },
+            "ipython_shell": get_ipython,
         }
         form_cell = parse_as_form_cell(data)
         assert form_cell.input_type == "checkboxes"
@@ -37,11 +38,12 @@ class TestParseFormCell:
             "value": "2023-01-01T00:00:00Z",
             "variable_type": "datetime",
             "settings": {},
+            "ipython_shell": get_ipython,
         }
         form_cell = parse_as_form_cell(data)
         assert form_cell.input_type == "datetime"
         assert form_cell.model_variable_name == "test"
-        assert form_cell.value == "2023-01-01T00:00:00+00:00"
+        assert form_cell.value == "2023-01-01T00:00"
         assert form_cell.variable_type == "datetime"
         assert form_cell.settings == {}
         assert isinstance(form_cell, Datetime)
@@ -50,16 +52,17 @@ class TestParseFormCell:
         data = {
             "input_type": "dropdown",
             "model_variable_name": "test",
-            "value": ["a"],
+            "value": "a",
             "variable_type": "str",
             "settings": {
                 "options": ["a", "b", "c"],
             },
+            "ipython_shell": get_ipython,
         }
         form_cell = parse_as_form_cell(data)
         assert form_cell.input_type == "dropdown"
         assert form_cell.model_variable_name == "test"
-        assert form_cell.value == ["a"]
+        assert form_cell.value == "a"
         assert form_cell.variable_type == "str"
         assert form_cell.settings.options == ["a", "b", "c"]
         assert isinstance(form_cell, Dropdown)
@@ -75,6 +78,7 @@ class TestParseFormCell:
                 "max": 100,
                 "step": 1,
             },
+            "ipython_shell": get_ipython,
         }
         form_cell = parse_as_form_cell(data)
         assert form_cell.input_type == "slider"
@@ -95,6 +99,7 @@ class TestParseFormCell:
                 "min_length": 0,
                 "max_length": 1000,
             },
+            "ipython_shell": get_ipython,
         }
         form_cell = parse_as_form_cell(data)
         assert form_cell.input_type == "text"
@@ -109,14 +114,16 @@ class TestParseFormCell:
             "input_type": "my_new_form_cell_type",
             "model_variable_name": "test",
             "value": "test",
-            "settings": {"min_foo": 0, "max_bar": 50},
-            "form_type": "new_plugin",
+            "foo": "bar",
+            "settings": {
+                "abc": "def",
+            },
+            "ipython_shell": get_ipython,
         }
         form_cell = parse_as_form_cell(data)
         assert form_cell.input_type == "custom"
         assert form_cell.model_variable_name == "test"
         assert form_cell.value == "test"
-        assert form_cell.settings.min_foo == 0
-        assert form_cell.settings.max_bar == 50
-        assert form_cell.form_type == "new_plugin"
+        assert form_cell.foo == "bar"
+        assert form_cell.settings.abc == "def"
         assert isinstance(form_cell, Custom)

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from IPython.core.interactiveshell import InteractiveShell
 
 from sidecar_comms.form_cells.base import (
@@ -204,3 +206,22 @@ class TestFormCellUpdates:
         form_cell.update(update_dict)
         assert form_cell.value == ["b", "x"]
         assert form_cell.settings.options == ["a", "b", "x", "y"]
+
+
+class TestFormCellObservers:
+    def test_callback_triggered_on_change(self):
+        """Test that a callback is triggered when the form cell value
+        is updated."""
+        data = {
+            "input_type": "checkboxes",
+            "model_variable_name": "test",
+            "value": ["a"],
+            "settings": {
+                "options": ["a", "b", "c"],
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        mock_callback = Mock()
+        form_cell.observe(mock_callback)
+        form_cell.value = ["b"]
+        mock_callback.assert_called_once_with({"name": "value", "old": ["a"], "new": ["b"]})

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -127,3 +127,39 @@ class TestParseFormCell:
         assert form_cell.foo == "bar"
         assert form_cell.settings.abc == "def"
         assert isinstance(form_cell, Custom)
+
+
+class TestFormCellSetup:
+    def test_value_variable_created(self, get_ipython: InteractiveShell):
+        """Test that a value variable is created and available in the
+        user namespace when a form cell is created."""
+        data = {
+            "input_type": "text",
+            "model_variable_name": "test",
+            "value": "test",
+            "settings": {
+                "min_length": 0,
+                "max_length": 1000,
+            },
+            "ipython_shell": get_ipython,
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.value_variable_name == "test_value"
+        assert "test_value" in get_ipython.user_ns
+
+    def test_value_variable_updated(self, get_ipython: InteractiveShell):
+        """Test that a value variable is updated when the form cell value
+        is updated."""
+        data = {
+            "input_type": "text",
+            "model_variable_name": "test",
+            "value": "test",
+            "settings": {
+                "min_length": 0,
+                "max_length": 1000,
+            },
+            "ipython_shell": get_ipython,
+        }
+        form_cell = parse_as_form_cell(data)
+        form_cell.value = "new value"
+        assert get_ipython.user_ns["test_value"] == "new value"

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -8,7 +8,6 @@ from sidecar_comms.form_cells.base import (
     Slider,
     Text,
     parse_as_form_cell,
-    update_form_cell,
 )
 
 
@@ -181,9 +180,9 @@ class TestFormCellUpdates:
         }
         form_cell = parse_as_form_cell(data)
         update_dict = {"settings": {"options": ["a", "b", "x", "y"]}}
-        updated_form_cell = update_form_cell(form_cell, update_dict)
-        assert updated_form_cell.value == ["a"]
-        assert updated_form_cell.settings.options == ["a", "b", "x", "y"]
+        form_cell.update(update_dict)
+        assert form_cell.value == ["a"]
+        assert form_cell.settings.options == ["a", "b", "x", "y"]
 
     def test_update_dict_value_settings(self):
         """Test that updating a form cell with a nested dictionary
@@ -202,6 +201,6 @@ class TestFormCellUpdates:
             "settings": {"options": ["a", "b", "x", "y"]},
             "value": ["b", "x"],
         }
-        updated_form_cell = update_form_cell(form_cell, update_dict)
-        assert updated_form_cell.value == ["b", "x"]
-        assert updated_form_cell.settings.options == ["a", "b", "x", "y"]
+        form_cell.update(update_dict)
+        assert form_cell.value == ["b", "x"]
+        assert form_cell.settings.options == ["a", "b", "x", "y"]

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -209,7 +209,7 @@ class TestFormCellUpdates:
 
 
 class TestFormCellObservers:
-    def test_callback_triggered_on_change(self):
+    def test_callback_triggered_on_value_change(self):
         """Test that a callback is triggered when the form cell value
         is updated."""
         data = {
@@ -225,3 +225,26 @@ class TestFormCellObservers:
         form_cell.observe(mock_callback)
         form_cell.value = ["b"]
         mock_callback.assert_called_once_with({"name": "value", "old": ["a"], "new": ["b"]})
+
+    def test_callback_triggered_on_settings_change(self):
+        """Test that a callback is triggered when the form cell settings
+        are updated."""
+        data = {
+            "input_type": "checkboxes",
+            "model_variable_name": "test",
+            "value": ["a"],
+            "settings": {
+                "options": ["a", "b", "c"],
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        mock_callback = Mock()
+        form_cell.settings.observe(mock_callback)
+        form_cell.settings.options = ["a", "b", "x", "y"]
+        mock_callback.assert_called_once_with(
+            {
+                "name": "options",
+                "old": ["a", "b", "c"],
+                "new": ["a", "b", "x", "y"],
+            }
+        )

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -8,6 +8,7 @@ from sidecar_comms.form_cells.base import (
     Slider,
     Text,
     parse_as_form_cell,
+    update_form_cell,
 )
 
 
@@ -163,3 +164,44 @@ class TestFormCellSetup:
         form_cell = parse_as_form_cell(data)
         form_cell.value = "new value"
         assert get_ipython.user_ns["test_value"] == "new value"
+
+
+class TestFormCellUpdates:
+    def test_update_dict_settings(self):
+        """Test that updating a form cell with a nested dictionary
+        updates the settings without dropping existing settings
+        or altering the original model structure."""
+        data = {
+            "input_type": "checkboxes",
+            "model_variable_name": "test",
+            "value": ["a"],
+            "settings": {
+                "options": ["a", "b", "c"],
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        update_dict = {"settings": {"options": ["a", "b", "x", "y"]}}
+        updated_form_cell = update_form_cell(form_cell, update_dict)
+        assert updated_form_cell.value == ["a"]
+        assert updated_form_cell.settings.options == ["a", "b", "x", "y"]
+
+    def test_update_dict_value_settings(self):
+        """Test that updating a form cell with a nested dictionary
+        updates the settings without dropping existing settings
+        or altering the original model structure."""
+        data = {
+            "input_type": "checkboxes",
+            "model_variable_name": "test",
+            "value": ["a"],
+            "settings": {
+                "options": ["a", "b", "c"],
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        update_dict = {
+            "settings": {"options": ["a", "b", "x", "y"]},
+            "value": ["b", "x"],
+        }
+        updated_form_cell = update_form_cell(form_cell, update_dict)
+        assert updated_form_cell.value == ["b", "x"]
+        assert updated_form_cell.settings.options == ["a", "b", "x", "y"]

--- a/tests/test_inbound/test_form_cells.py
+++ b/tests/test_inbound/test_form_cells.py
@@ -1,0 +1,122 @@
+from IPython.core.interactiveshell import InteractiveShell
+
+from sidecar_comms.form_cells.base import (
+    Checkboxes,
+    Custom,
+    Datetime,
+    Dropdown,
+    Slider,
+    Text,
+    parse_as_form_cell,
+)
+
+
+class TestParseFormCell:
+    def test_parse_checkboxes(self, get_ipython: InteractiveShell):
+        data = {
+            "input_type": "checkboxes",
+            "model_variable_name": "test",
+            "value": ["test"],
+            "variable_type": "str",
+            "settings": {
+                "options": ["test"],
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.input_type == "checkboxes"
+        assert form_cell.model_variable_name == "test"
+        assert form_cell.value == ["test"]
+        assert form_cell.variable_type == "str"
+        assert form_cell.settings.options == ["test"]
+        assert isinstance(form_cell, Checkboxes)
+
+    def test_parse_datetime(self, get_ipython: InteractiveShell):
+        data = {
+            "input_type": "datetime",
+            "model_variable_name": "test",
+            "value": "2023-01-01T00:00:00Z",
+            "variable_type": "datetime",
+            "settings": {},
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.input_type == "datetime"
+        assert form_cell.model_variable_name == "test"
+        assert form_cell.value == "2023-01-01T00:00:00+00:00"
+        assert form_cell.variable_type == "datetime"
+        assert form_cell.settings == {}
+        assert isinstance(form_cell, Datetime)
+
+    def test_parse_dropdown(self, get_ipython: InteractiveShell):
+        data = {
+            "input_type": "dropdown",
+            "model_variable_name": "test",
+            "value": ["a"],
+            "variable_type": "str",
+            "settings": {
+                "options": ["a", "b", "c"],
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.input_type == "dropdown"
+        assert form_cell.model_variable_name == "test"
+        assert form_cell.value == ["a"]
+        assert form_cell.variable_type == "str"
+        assert form_cell.settings.options == ["a", "b", "c"]
+        assert isinstance(form_cell, Dropdown)
+
+    def test_parse_slider(self, get_ipython: InteractiveShell):
+        data = {
+            "input_type": "slider",
+            "model_variable_name": "test",
+            "value": 0,
+            "variable_type": "int",
+            "settings": {
+                "min": 0,
+                "max": 100,
+                "step": 1,
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.input_type == "slider"
+        assert form_cell.model_variable_name == "test"
+        assert form_cell.value == 0
+        assert form_cell.variable_type == "int"
+        assert form_cell.settings.min == 0
+        assert form_cell.settings.max == 100
+        assert form_cell.settings.step == 1
+        assert isinstance(form_cell, Slider)
+
+    def test_parse_text(self, get_ipython: InteractiveShell):
+        data = {
+            "input_type": "text",
+            "model_variable_name": "test",
+            "value": "test",
+            "settings": {
+                "min_length": 0,
+                "max_length": 1000,
+            },
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.input_type == "text"
+        assert form_cell.model_variable_name == "test"
+        assert form_cell.value == "test"
+        assert form_cell.settings.min_length == 0
+        assert form_cell.settings.max_length == 1000
+        assert isinstance(form_cell, Text)
+
+    def test_parse_custom(self, get_ipython: InteractiveShell):
+        data = {
+            "input_type": "my_new_form_cell_type",
+            "model_variable_name": "test",
+            "value": "test",
+            "settings": {"min_foo": 0, "max_bar": 50},
+            "form_type": "new_plugin",
+        }
+        form_cell = parse_as_form_cell(data)
+        assert form_cell.input_type == "custom"
+        assert form_cell.model_variable_name == "test"
+        assert form_cell.value == "test"
+        assert form_cell.settings.min_foo == 0
+        assert form_cell.settings.max_bar == 50
+        assert form_cell.form_type == "new_plugin"
+        assert isinstance(form_cell, Custom)

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -4,14 +4,6 @@ from sidecar_comms.handlers.variable_explorer import get_kernel_variables, short
 
 
 class TestGetKernelVariables:
-    def test_blank_slate(self, get_ipython: InteractiveShell):
-        """Test that a basic call to get_kernel_variables without any
-        variables declared returns an empty dict."""
-        variables = get_kernel_variables(ipython_shell=get_ipython)
-        # initial run should be empty based on the skip_prefixes
-        assert isinstance(variables, dict)
-        assert variables == {}
-
     def test_skip_prefixes(self, get_ipython: InteractiveShell):
         """Test that the skip_prefixes are working as expected."""
         get_ipython.user_ns["foo"] = 123

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -3,44 +3,73 @@ from IPython.core.interactiveshell import InteractiveShell
 from sidecar_comms.handlers.variable_explorer import get_kernel_variables, short_value
 
 
-def test_get_kernel_variables(get_ipython: InteractiveShell):
-    variables = get_kernel_variables(ipython_shell=get_ipython)
-    # initial run should be empty based on the skip_prefixes
-    assert isinstance(variables, dict)
-    assert variables == {}
+class TestGetKernelVariables:
+    def test_blank_slate(self, get_ipython: InteractiveShell):
+        """Test that a basic call to get_kernel_variables without any
+        variables declared returns an empty dict."""
+        variables = get_kernel_variables(ipython_shell=get_ipython)
+        # initial run should be empty based on the skip_prefixes
+        assert isinstance(variables, dict)
+        assert variables == {}
 
-    get_ipython.user_ns["foo"] = 123
-    variables = get_kernel_variables(ipython_shell=get_ipython)
-    # add a basic integer variable
-    assert "foo" in variables
-    assert variables["foo"]["name"] == "foo"
-    assert variables["foo"]["type"] == "int"
-    assert variables["foo"]["size"] == 1
-    assert variables["foo"]["value"] == 123
+    def test_skip_prefixes(self, get_ipython: InteractiveShell):
+        """Test that the skip_prefixes are working as expected."""
+        get_ipython.user_ns["foo"] = 123
+        get_ipython.user_ns["bar"] = 456
+        get_ipython.user_ns["_baz"] = 789
+        get_ipython.user_ns["SECRET_abc"] = 123
+        variables = get_kernel_variables(skip_prefixes=["_", "SECRET_"], ipython_shell=get_ipython)
+        # initial run should be empty based on the skip_prefixes
+        assert isinstance(variables, dict)
+        assert "foo" in variables
+        assert "bar" in variables
+        assert "_baz" not in variables
+        assert "SECRET_abc" not in variables
 
-    get_ipython.user_ns["bar"] = [1, 2, 3]
-    variables = get_kernel_variables(ipython_shell=get_ipython)
-    # add a list variable
-    assert "bar" in variables
-    assert variables["bar"]["name"] == "bar"
-    assert variables["bar"]["type"] == "list"
-    assert variables["bar"]["size"] == 3
-    assert variables["bar"]["value"] == [1, 2, 3]
+    def test_integer(self, get_ipython: InteractiveShell):
+        """Test that a basic integer variable is added to the variables
+        response with the correct information."""
+        get_ipython.user_ns["foo"] = 123
+        variables = get_kernel_variables(ipython_shell=get_ipython)
+        # add a basic integer variable
+        assert "foo" in variables
+        assert variables["foo"]["name"] == "foo"
+        assert variables["foo"]["type"] == "int"
+        assert variables["foo"]["size"] == 1
+        assert variables["foo"]["value"] == 123
 
-    get_ipython.user_ns["baz"] = {"a": 1, "b": 2, "c": 3, "d": 4}
-    variables = get_kernel_variables(ipython_shell=get_ipython)
-    # add a dict variable
-    assert "baz" in variables
-    assert variables["baz"]["name"] == "baz"
-    assert variables["baz"]["type"] == "dict"
-    assert variables["baz"]["size"] == 4
-    assert variables["baz"]["value"] == {"a": 1, "b": 2, "c": 3, "d": 4}.keys()
+    def test_list(self, get_ipython: InteractiveShell):
+        """Test that a basic list variable is added to the variables
+        response with the correct information."""
+        get_ipython.user_ns["bar"] = [1, 2, 3]
+        variables = get_kernel_variables(ipython_shell=get_ipython)
+        # add a list variable
+        assert "bar" in variables
+        assert variables["bar"]["name"] == "bar"
+        assert variables["bar"]["type"] == "list"
+        assert variables["bar"]["size"] == 3
+        assert variables["bar"]["value"] == [1, 2, 3]
 
-    get_ipython.user_ns["qux"] = "ABC" * 5000
-    variables = get_kernel_variables(ipython_shell=get_ipython)
-    # add a long string variable
-    assert "qux" in variables
-    assert variables["qux"]["name"] == "qux"
-    assert variables["qux"]["type"] == "str"
-    assert variables["qux"]["size"] == 15000
-    assert variables["qux"]["value"] == short_value("ABC" * 5000)
+    def test_dict(self, get_ipython: InteractiveShell):
+        """Test that a basic dict variable is added to the variables
+        response with the correct information."""
+        get_ipython.user_ns["baz"] = {"a": 1, "b": 2, "c": 3, "d": 4}
+        variables = get_kernel_variables(ipython_shell=get_ipython)
+        # add a dict variable
+        assert "baz" in variables
+        assert variables["baz"]["name"] == "baz"
+        assert variables["baz"]["type"] == "dict"
+        assert variables["baz"]["size"] == 4
+        assert variables["baz"]["value"] == {"a": 1, "b": 2, "c": 3, "d": 4}.keys()
+
+    def test_long_string(self, get_ipython: InteractiveShell):
+        """Test that a long string variable is added to the variables
+        response with the correct information."""
+        get_ipython.user_ns["qux"] = "ABC" * 5000
+        variables = get_kernel_variables(ipython_shell=get_ipython)
+        # add a long string variable
+        assert "qux" in variables
+        assert variables["qux"]["name"] == "qux"
+        assert variables["qux"]["type"] == "str"
+        assert variables["qux"]["size"] == 15000
+        assert variables["qux"]["value"] == short_value("ABC" * 5000)

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -1,0 +1,46 @@
+from IPython.core.interactiveshell import InteractiveShell
+
+from sidecar_comms.handlers.variable_explorer import get_kernel_variables, short_value
+
+
+def test_get_kernel_variables(get_ipython: InteractiveShell):
+    variables = get_kernel_variables(ipython_shell=get_ipython)
+    # initial run should be empty based on the skip_prefixes
+    assert isinstance(variables, dict)
+    assert variables == {}
+
+    get_ipython.user_ns["foo"] = 123
+    variables = get_kernel_variables(ipython_shell=get_ipython)
+    # add a basic integer variable
+    assert "foo" in variables
+    assert variables["foo"]["name"] == "foo"
+    assert variables["foo"]["type"] == "int"
+    assert variables["foo"]["size"] == 1
+    assert variables["foo"]["value"] == 123
+
+    get_ipython.user_ns["bar"] = [1, 2, 3]
+    variables = get_kernel_variables(ipython_shell=get_ipython)
+    # add a list variable
+    assert "bar" in variables
+    assert variables["bar"]["name"] == "bar"
+    assert variables["bar"]["type"] == "list"
+    assert variables["bar"]["size"] == 3
+    assert variables["bar"]["value"] == [1, 2, 3]
+
+    get_ipython.user_ns["baz"] = {"a": 1, "b": 2, "c": 3, "d": 4}
+    variables = get_kernel_variables(ipython_shell=get_ipython)
+    # add a dict variable
+    assert "baz" in variables
+    assert variables["baz"]["name"] == "baz"
+    assert variables["baz"]["type"] == "dict"
+    assert variables["baz"]["size"] == 4
+    assert variables["baz"]["value"] == {"a": 1, "b": 2, "c": 3, "d": 4}.keys()
+
+    get_ipython.user_ns["qux"] = "ABC" * 5000
+    variables = get_kernel_variables(ipython_shell=get_ipython)
+    # add a long string variable
+    assert "qux" in variables
+    assert variables["qux"]["name"] == "qux"
+    assert variables["qux"]["type"] == "str"
+    assert variables["qux"]["size"] == 15000
+    assert variables["qux"]["value"] == short_value("ABC" * 5000)


### PR DESCRIPTION
### Added
- form cell and variable tests
- form cell `update()` (inplace) method

### Changed
- `get_kernel_variables()` return structure to include `name/type/size/value` properties, shortening `value` if the value size in memory is over 1000 bytes
- Non-standard form cell observer callbacks are now copied during deep form cell updates / recreation 

### Fixed
- `variable_type` is no longer required for Checkboxes or Dropdown form cells

### Removed
- `deepmerge` to address form cell updates' list attributes duplicating; follow-on PR needed to handle any deeper merges since we're manually checking for `settings` and calling `setattr` directly on any `settings` key/value pairs