### PR TITLE
variable explorer message updates

### DIFF
--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -54,11 +54,11 @@ def variable_size(value: Any) -> Optional[Union[int, tuple]]:
     For iterables, this returns the length / number of items.
     For matrix-like objects, this returns a tuple of the number of rows/columns, similar to .shape.
     """
-    if hasattr(value, "__len__"):
-        return len(value)
-
     if (shape := variable_shape(value)) is not None:
         return shape
+
+    if hasattr(value, "__len__"):
+        return len(value)
 
     if (size := getattr(value, "size", None)) is None:
         return

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -149,10 +149,13 @@ def variable_to_model(name: str, value: Any) -> VariableModel:
 
 
 def json_clean(value: Any, max_length: Optional[int] = None) -> str:
-    """Converts a variable data dictionary to a JSON string."""
+    """Ensures a value is JSON serializable, converting to a string if necessary.
+
+    Recursively cleans values of dictionaries, and items in lists, sets, and tuples
+    if necessary.
+    """
     max_length = max_length or MAX_STRING_LENGTH
 
-    # recursively clean if necessary
     if isinstance(value, dict):
         value = {k: json_clean(v) for k, v in value.items()}
     elif isinstance(value, tuple(CONTAINER_TYPES)):

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -1,30 +1,64 @@
 import json
 import sys
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from IPython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell
+from pydantic import BaseModel
 
 
-def short_value(value: Any) -> str:
-    """Returns a short representation of a value."""
-    if isinstance(value, list):
-        return value[:5]
-    if isinstance(value, dict):
-        return value.keys()
-    if sys.getsizeof(value) > 1000:
-        return f"{value!r}"[:100] + "..."
-
-    try:
-        json.dumps(value)
-        return value
-    except Exception:
-        # non-JSON serializable
-        return f"{value!r}"[:100]
+class VariableModel(BaseModel):
+    name: str
+    type: str
+    docstring: Optional[str]
+    module: Optional[str]
+    sample_value: Any  # may be the full value if small enough, only truncated for larger values
+    shape: Optional[Tuple]
+    size: Optional[int]
+    size_bytes: Optional[int]
+    error: Optional[str]
 
 
-def get_memory_footprint(value: Any) -> Optional[int]:
-    """Returns the memory footprint of a value."""
+def variable_docstring(value: Any) -> Optional[str]:
+    """Returns the docstring of a variable."""
+    if (doc := getattr(value, "__doc__", None)) is None:
+        return
+    if not isinstance(doc, str):
+        return
+    return doc[:5000]
+
+
+def variable_type(value: Any) -> str:
+    return type(value).__name__
+
+
+def variable_size(value: Any) -> Optional[int]:
+    """Returns the size (1-dimensional; length) of a variable."""
+    if hasattr(value, "__len__"):
+        return len(value)
+    if (size := getattr(value, "size", None)) is None:
+        return
+    if isinstance(size, int):
+        return size
+    if isinstance(size, tuple):
+        return size[0]
+
+
+def variable_shape(value: Any) -> Optional[int]:
+    """Returns the shape (n-dimensional; rows, columns, ...) of a variable."""
+    if (shape := getattr(value, "shape", None)) is None:
+        return
+    if not isinstance(shape, tuple):
+        return
+    if not shape:
+        return
+    if not isinstance(shape[0], int):
+        return
+    return shape
+
+
+def variable_size_bytes(value: Any) -> Optional[int]:
+    """Returns the size of a variable in bytes."""
     try:
         return sys.getsizeof(value)
     except Exception:
@@ -36,6 +70,54 @@ def get_memory_footprint(value: Any) -> Optional[int]:
         return value.memory_usage().sum()
     except Exception:
         pass
+
+
+def variable_sample_value(value: Any) -> Any:
+    """Returns a short representation of a value."""
+    if isinstance(value, list):
+        # TODO: come back to this and maybe recursively check
+        # items in container
+        return value[:5]
+    if isinstance(value, dict):
+        return value.keys()
+    if variable_size_bytes(value) > 1000:
+        return f"{value!r}"[:1000] + "..."
+    try:
+        json.dumps(value)
+        return value
+    except Exception:
+        # non-JSON serializable
+        return f"{value!r}"[:1000]
+
+
+def variable_to_model(name: str, value: Any) -> VariableModel:
+    """Gathers properties of a variable to send to the sidecar through
+    a variable explorer comm message.
+    Should always have `name` and `type` properties; `error` will show
+    conversion/inspection errors for size/size_bytes/sample_value.
+    """
+    basic_props = {
+        "name": name,
+        "docstring": variable_docstring(value),
+        "type": variable_type(value),
+        "module": getattr(value, "__module__", None),
+    }
+
+    # in the event we run into any parsing/validation errors,
+    # we'll still send the variable model with basic properties
+    # and an error message
+    try:
+        return VariableModel(
+            sample_value=variable_sample_value(value),
+            shape=variable_shape(value),
+            size=variable_size(value),
+            size_bytes=variable_size_bytes(value),
+            **basic_props,
+        )
+    except Exception as e:
+        basic_props["error"] = str(e)
+
+    return VariableModel(**basic_props)
 
 
 def get_kernel_variables(
@@ -58,13 +140,8 @@ def get_kernel_variables(
     for name, value in variables.items():
         if name.startswith(tuple(skip_prefixes)):
             continue
-        variable_types[name] = {
-            "name": name,
-            "type": type(value).__name__,
-            "size": len(value) if hasattr(value, "__len__") else 1,
-            "size_bytes": get_memory_footprint(value),
-            "value": short_value(value),
-        }
+        variable_model = variable_to_model(name=name, value=value)
+        variable_types[name] = variable_model.dict()
     return variable_types
 
 

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -71,22 +71,26 @@ def variable_size_bytes(value: Any) -> Optional[int]:
         pass
 
 
-def variable_sample_value(value: Any) -> Any:
+def variable_sample_value(value: Any, max_length: int = 1000) -> Any:
     """Returns a short representation of a value."""
     sample_value = None
-    if isinstance(value, list):
-        sample_value = [variable_sample_value(item) for item in value[:5]]
+    if isinstance(value, (list, set, tuple)):
+        sample_items = [
+            variable_sample_value(item, max_length=max_length) for item in list(value)[:5]
+        ]
+        container_type = type(value)
+        sample_value = container_type(sample_items)
     elif isinstance(value, dict):
         sample_value = value.keys()
-    elif variable_size_bytes(value) > 1000:
-        sample_value = f"{value!r}"[:1000] + "..."
+    elif variable_size_bytes(value) > max_length:
+        sample_value = f"{value!r}"[:max_length] + "..."
 
     try:
         json.dumps(sample_value)
         return sample_value
     except ValueError:
         # can't JSON serialize; stringify it and move on
-        return f"{sample_value!r}"[:5000]
+        return f"{sample_value!r}"[:max_length]
 
 
 def variable_to_model(name: str, value: Any) -> VariableModel:

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -73,20 +73,20 @@ def variable_size_bytes(value: Any) -> Optional[int]:
 
 def variable_sample_value(value: Any) -> Any:
     """Returns a short representation of a value."""
+    sample_value = None
     if isinstance(value, list):
-        # TODO: come back to this and maybe recursively check
-        # items in container
-        return value[:5]
-    if isinstance(value, dict):
-        return value.keys()
-    if variable_size_bytes(value) > 1000:
-        return f"{value!r}"[:1000] + "..."
+        sample_value = [variable_sample_value(item) for item in value[:5]]
+    elif isinstance(value, dict):
+        sample_value = value.keys()
+    elif variable_size_bytes(value) > 1000:
+        sample_value = f"{value!r}"[:1000] + "..."
+
     try:
-        json.dumps(value)
-        return value
-    except Exception:
-        # non-JSON serializable
-        return f"{value!r}"[:1000]
+        json.dumps(sample_value)
+        return sample_value
+    except ValueError:
+        # can't JSON serialize; stringify it and move on
+        return f"{sample_value!r}"[:5000]
 
 
 def variable_to_model(name: str, value: Any) -> VariableModel:

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -52,7 +52,7 @@ class TestGetKernelVariables:
         assert variables["baz"]["name"] == "baz"
         assert variables["baz"]["type"] == "dict"
         assert variables["baz"]["size"] == 4
-        assert variables["baz"]["sample_value"] == {"a": 1, "b": 2, "c": 3, "d": 4}.keys()
+        assert variables["baz"]["sample_value"] == {"a": 1, "b": 2, "c": 3, "d": 4}
 
     def test_long_string(self):
         """Test that a long string variable is added to the variables

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from sidecar_comms.handlers.variable_explorer import get_kernel_variables, variable_sample_value
 from sidecar_comms.shell import get_ipython_shell
 

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -23,38 +23,42 @@ class TestGetKernelVariables:
     def test_integer(self):
         """Test that a basic integer variable is added to the variables
         response with the correct information."""
-        get_ipython_shell().user_ns["foo"] = 123
+        variable_name = "foo"
+        variable_value = 123
+        get_ipython_shell().user_ns[variable_name] = variable_value
         variables = get_kernel_variables()
         # add a basic integer variable
-        assert "foo" in variables
-        assert variables["foo"]["name"] == "foo"
-        assert variables["foo"]["type"] == "int"
-        assert variables["foo"]["size"] is None
-        assert variables["foo"]["sample_value"] == 123
+        assert variable_name in variables
+        assert variables[variable_name]["name"] == variable_name
+        assert variables[variable_name]["type"] == "int"
+        assert variables[variable_name]["size"] is None
+        assert variables[variable_name]["sample_value"] == variable_value
 
     def test_list(self):
         """Test that a basic list variable is added to the variables
         response with the correct information."""
-        get_ipython_shell().user_ns["bar"] = [1, 2, 3]
+        variable_name = "bar"
+        variable_value = [1, 2, 3]
+        get_ipython_shell().user_ns[variable_name] = variable_value
         variables = get_kernel_variables()
-        # add a list variable
-        assert "bar" in variables
-        assert variables["bar"]["name"] == "bar"
-        assert variables["bar"]["type"] == "list"
-        assert variables["bar"]["size"] == 3
-        assert variables["bar"]["sample_value"] == [1, 2, 3]
+        assert variable_name in variables
+        assert variables[variable_name]["name"] == variable_name
+        assert variables[variable_name]["type"] == "list"
+        assert variables[variable_name]["size"] == 3
+        assert variables[variable_name]["sample_value"] == variable_value
 
     def test_dict(self):
         """Test that a basic dict variable is added to the variables
         response with the correct information."""
-        get_ipython_shell().user_ns["baz"] = {"a": 1, "b": 2, "c": 3, "d": 4}
+        variable_name = "baz"
+        variable_value = {"a": 1, "b": 2, "c": 3, "d": 4}
+        get_ipython_shell().user_ns[variable_name] = variable_value
         variables = get_kernel_variables()
-        # add a dict variable
-        assert "baz" in variables
-        assert variables["baz"]["name"] == "baz"
-        assert variables["baz"]["type"] == "dict"
-        assert variables["baz"]["size"] == 4
-        assert variables["baz"]["sample_value"] == {"a": 1, "b": 2, "c": 3, "d": 4}
+        assert variable_name in variables
+        assert variables[variable_name]["name"] == variable_name
+        assert variables[variable_name]["type"] == "dict"
+        assert variables[variable_name]["size"] == 4
+        assert variables[variable_name]["sample_value"] == variable_value
 
     def test_long_string(self):
         """Test that a long string variable is added to the variables
@@ -63,12 +67,11 @@ class TestGetKernelVariables:
         variable_value = "ABC" * 5000
         get_ipython_shell().user_ns[variable_name] = variable_value
         variables = get_kernel_variables()
-        # add a long string variable
-        assert "qux" in variables
-        assert variables["qux"]["name"] == "qux"
-        assert variables["qux"]["type"] == "str"
-        assert variables["qux"]["size"] == 15000
-        assert variables["qux"]["sample_value"] == variable_sample_value(variable_value)
+        assert variable_name in variables
+        assert variables[variable_name]["name"] == variable_name
+        assert variables[variable_name]["type"] == "str"
+        assert variables[variable_name]["size"] == len(variable_value)
+        assert variables[variable_name]["sample_value"] == variable_sample_value(variable_value)
 
     def test_fn(self):
         """Test that a variable assigned to a function is added to the variables
@@ -85,6 +88,7 @@ class TestGetKernelVariables:
         assert variable_name in variables
         assert variables[variable_name]["name"] == variable_name
         assert variables[variable_name]["type"] == "function"
+        assert variables[variable_name]["size"] is None
         assert variables[variable_name]["sample_value"].startswith("<function")
 
     def test_fn_in_list(self):
@@ -102,7 +106,9 @@ class TestGetKernelVariables:
         assert variable_name in variables
         assert variables[variable_name]["name"] == variable_name
         assert variables[variable_name]["type"] == "list"
+        assert variables[variable_name]["size"] == 1
         assert isinstance(variables[variable_name]["sample_value"], list)
+        assert isinstance(variables[variable_name]["sample_value"][0], str)
         assert variables[variable_name]["sample_value"][0].startswith("<function")
 
     def test_broken_property(self):
@@ -114,7 +120,9 @@ class TestGetKernelVariables:
             def __len__(self):
                 raise Exception("I'm broken!")
 
-        get_ipython_shell().user_ns["test_dict"] = Foo()
+        variable_name = "test_foo"
+        variable_value = Foo()
+        get_ipython_shell().user_ns[variable_name] = variable_value
         variables = get_kernel_variables()
-        assert "test_dict" in variables
-        assert variables["test_dict"].get("error") is not None
+        assert variable_name in variables
+        assert variables[variable_name].get("error") is not None


### PR DESCRIPTION
Message updates to add `error` for any parsing/validation issues, as well as `module` and `docstring`.

Removes `shape` from the message, allowing `size` to instead pass either an integer or tuple of integer values.

Adds some extra guarding against values that aren't JSON serializable before passing the VariableModel dictionary over via comms.