### PR TITLE
don't send `sample_value` on non-JSON-serializable variable value

### DIFF
--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -52,16 +52,15 @@ def variable_string_repr(value: Any, max_length: Optional[int] = None) -> str:
     if PANDAS_INSTALLED and variable_type(value) == "DataFrame":
         # if any of these are set to custom values, we need to revert them to the
         # pandas defaults, otherwise the repr may take an unnecessarily long time
-        orig_max_rows = pd.get_option("display.max_rows")
-        orig_max_columns = pd.get_option("display.max_columns")
-        orig_max_colwidth = pd.get_option("display.max_colwidth")
-        pd.set_option("display.max_rows", 20)
-        pd.set_option("display.max_columns", 60)
-        pd.set_option("display.max_colwidth", 50)
-        string_repr = repr(value)
-        pd.set_option("display.max_rows", orig_max_rows)
-        pd.set_option("display.max_columns", orig_max_columns)
-        pd.set_option("display.max_colwidth", orig_max_colwidth)
+        with pd.option_context(
+            "display.max_rows",
+            60,
+            "display.max_columns",
+            20,
+            "display.max_colwidth",
+            50,
+        ):
+            string_repr = repr(value)
 
     else:
         string_repr = repr(value)

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -113,7 +113,9 @@ def variable_extra_properties(value: Any) -> Optional[dict]:
     if variable_type(value) == "DataFrame":
         extra["columns"] = list(value.columns)[:100]
         extra["index"] = list(value.index)[:100]
-        extra["dtypes"] = dict(value.dtypes)
+        # ensure we can still pass the string dtype through,
+        # since they aren't JSON serializable
+        extra["dtypes"] = {name: str(dtype) for name, dtype in dict(value.dtypes).items()}
 
     if variable_type(value) == "dict":
         extra["keys"] = list(value.keys())[:100]

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -99,10 +99,7 @@ def variable_sample_value(value: Any, max_length: Optional[int] = None) -> Any:
         return
 
     if variable_size_bytes(sample_value) > max_length:
-        if isinstance(sample_value, dict):
-            sample_value = sample_value.keys()
-        else:
-            sample_value = repr(sample_value)[:max_length] + "..."
+        sample_value = repr(sample_value)[:max_length] + "..."
 
     return sample_value
 
@@ -117,6 +114,9 @@ def variable_extra_properties(value: Any) -> Optional[dict]:
         extra["columns"] = list(value.columns)[:100]
         extra["index"] = list(value.index)[:100]
         extra["dtypes"] = dict(value.dtypes)
+
+    if variable_type(value) == "dict":
+        extra["keys"] = list(value.keys())[:100]
 
     return extra
 

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -87,7 +87,8 @@ class TestGetKernelVariables:
         assert variables[variable_name]["name"] == variable_name
         assert variables[variable_name]["type"] == "function"
         assert variables[variable_name]["size"] is None
-        assert variables[variable_name]["sample_value"].startswith("<function")
+        # functions aren't JSON-serializable, so the sample value should be None
+        assert variables[variable_name]["sample_value"] is None
 
     def test_fn_in_list(self):
         """Test that a variable assigned to a function in a list is added
@@ -106,8 +107,8 @@ class TestGetKernelVariables:
         assert variables[variable_name]["type"] == "list"
         assert variables[variable_name]["size"] == 1
         assert isinstance(variables[variable_name]["sample_value"], list)
-        assert isinstance(variables[variable_name]["sample_value"][0], str)
-        assert variables[variable_name]["sample_value"][0].startswith("<function")
+        # functions aren't JSON-serializable, so the first item in the sample value should be None
+        assert variables[variable_name]["sample_value"][0] is None
 
     def test_broken_property(self):
         """Test that a variable with an unexpected/unhandled property type will


### PR DESCRIPTION
Avoids scenarios where we may spend unnecessary processing time attempting to `repr()` a (potentially large) value, such as a pandas DataFrame. Without interfering with any custom display formatter callbacks/configs, this is the safest/fastest solution to non-JSON-serializable values.