### PR TITLE
update `Datetime` form cell model and validation

### DIFF
--- a/src/sidecar_comms/form_cells/base.py
+++ b/src/sidecar_comms/form_cells/base.py
@@ -128,7 +128,7 @@ class FormCellBase(ObservableModel):
 # --- Specific models ---
 class Datetime(FormCellBase):
     input_type: Literal["datetime"] = "datetime"
-    value: str = Field(default_factory=lambda: datetime.now(timezone.utc))
+    value: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     @validator("value", pre=True, always=True)
     def validate_value(cls, value):
@@ -137,8 +137,6 @@ class Datetime(FormCellBase):
             if value.endswith("Z"):
                 value = value.replace("Z", "+00:00")
             value = datetime.fromisoformat(value)
-        if isinstance(value, datetime):
-            value = value.strftime("%Y-%m-%dT%H:%M")
         return value
 
 

--- a/src/sidecar_comms/inbound.py
+++ b/src/sidecar_comms/inbound.py
@@ -7,7 +7,11 @@ import traceback
 from ipykernel.comm import Comm
 from IPython import get_ipython
 
-from sidecar_comms.form_cells.base import FORM_CELL_CACHE, parse_as_form_cell
+from sidecar_comms.form_cells.base import (
+    FORM_CELL_CACHE,
+    parse_as_form_cell,
+    validate_datetime_value,
+)
 from sidecar_comms.handlers.variable_explorer import (
     get_kernel_variables,
     rename_kernel_variable,
@@ -67,6 +71,12 @@ def handle_msg(data: dict, comm: Comm) -> None:
     if inbound_msg == "update_form_cell":
         form_cell_id = data.pop("form_cell_id")
         form_cell = FORM_CELL_CACHE[form_cell_id]
+
+        if data["input_type"] == "datetime":
+            # specifically convert back to datetime object;
+            # otherwise the value variable will remain a string
+            data["value"] = validate_datetime_value(data["value"])
+
         form_cell.update(data)
         msg = CommMessage(
             body=form_cell.dict(),


### PR DESCRIPTION
- sets `value` to datetime
- validates string -> datetime when a comm is received to update the form cell
- converts datetime -> string before sending a sync comm back to the sidecar