### PR TITLE
remove dtypes/index from variable explorer data

### DIFF
--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -153,8 +153,9 @@ def variable_extra_properties(value: Any) -> Optional[dict]:
     if variable_type(value) == "DataFrame":
         columns = variable_extra_list_property(value, "columns")
         extra["columns"] = columns
-        extra["dtypes"] = variable_extra_dtypes(value, columns)
-        extra["index"] = variable_extra_list_property(value, "index")
+        # removing dtypes and index
+        # extra["dtypes"] = variable_extra_dtypes(value, columns)
+        # extra["index"] = variable_extra_list_property(value, "index")
 
     if variable_type(value) == "dict":
         extra["keys"] = list(value.keys())[:100]

--- a/src/sidecar_comms/handlers/variable_explorer.py
+++ b/src/sidecar_comms/handlers/variable_explorer.py
@@ -153,7 +153,7 @@ def variable_extra_properties(value: Any) -> Optional[dict]:
     if variable_type(value) == "DataFrame":
         columns = variable_extra_list_property(value, "columns")
         extra["columns"] = columns
-        # removing dtypes and index
+        # temporarily removing dtypes and index for performance reasons
         # extra["dtypes"] = variable_extra_dtypes(value, columns)
         # extra["index"] = variable_extra_list_property(value, "index")
 

--- a/tests/test_inbound/test_variable_explorer.py
+++ b/tests/test_inbound/test_variable_explorer.py
@@ -170,6 +170,7 @@ class TestDataFrameVariables:
             assert variables[variable_name]["type"] == "DataFrame"
             assert variables[variable_name]["error"] is None
             assert isinstance(variables[variable_name]["extra"]["columns"], list)
-            assert isinstance(variables[variable_name]["extra"]["dtypes"], dict)
             assert "a" in variables[variable_name]["extra"]["columns"]
-            assert "a" in variables[variable_name]["extra"]["dtypes"]
+            if "dtypes" in variables[variable_name]["extra"]:
+                assert isinstance(variables[variable_name]["extra"]["dtypes"], dict)
+                assert "a" in variables[variable_name]["extra"]["dtypes"]


### PR DESCRIPTION
Could add a lot of unneeded bloat to message sizes